### PR TITLE
Provide fallback if icon 404s (Close #26)

### DIFF
--- a/public/javascripts/apps.js
+++ b/public/javascripts/apps.js
@@ -96,7 +96,7 @@ define(function(require, exports, module) {
   function wrapRecommendation(app) {
     return {
       appObject: app,
-      imageURL: app.icon_url,
+      imageURL: app.icon_url_128 || '/images/openbox.png',
       name: app.name,
       recommendation: true,
       url: app.absolute_url

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -95,6 +95,10 @@ define(function(require) {
     var app = Apps.wrapRecommendation(recommendations['Games'].random());
     var template = new EJS({url: '/templates/recommendation.ejs'});
     $('.cell')[RECOMMENDATION_SQUARE].outerHTML = template.render({recommendation: app});
+
+    $('.recommendation .thumbnail')[0].addEventListener('error', function() {
+      this.src = '/images/openbox.png';
+    });
   }
 
   // Listen for drag events on the cells in the page.


### PR DESCRIPTION
Use the onError event for all images with remote URLs; on the off-chance
their icons are missing, we replace it with the openbox.png placeholder
image.
